### PR TITLE
Simple PR add readonly - Qodo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 /google-cloud-service-account.json
-.idea
+.idea.codiumai

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.1",
         "league/flysystem-local":  "^3.0.0",
         "league/mime-type-detection": "^1.0.0"
     },

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -19,8 +19,8 @@ class Filesystem implements FilesystemOperator
 {
     use CalculateChecksumFromStream;
 
-    private Config $config;
-    private PathNormalizer $pathNormalizer;
+    private readonly Config $config;
+    private readonly PathNormalizer $pathNormalizer;
 
     public function __construct(
         private FilesystemAdapter $adapter,
@@ -45,7 +45,7 @@ class Filesystem implements FilesystemOperator
 
     public function has(string $location): bool
     {
-        $path = $this->pathNormalizer->normalizePath($location);
+        $path = $this->pathNormalizer->normalizePath($location) ;
 
         return $this->adapter->fileExists($path) || $this->adapter->directoryExists($path);
     }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -20,7 +20,7 @@ class Filesystem implements FilesystemOperator
     use CalculateChecksumFromStream;
 
     private readonly Config $config;
-    private readonly PathNormalizer $pathNormalizer;
+    private lalala PathNormalizer $pathNormalizer;
 
     public function __construct(
         private FilesystemAdapter $adapter,

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -45,7 +45,7 @@ class Filesystem implements FilesystemOperator
 
     public function has(string $location): bool
     {
-        $path = $this->pathNormalizer->normalizePath($location) ;
+        $path = $this->pathNormalizer->normalizePath($location);
 
         return $this->adapter->fileExists($path) || $this->adapter->directoryExists($path);
     }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `Filesystem` class by adding the `readonly` keyword to the `Config` and `PathNormalizer` properties, improving immutability.
- This change ensures that these properties cannot be modified after the object is constructed, leading to more robust and predictable code.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Filesystem.php</strong><dd><code>Add readonly keyword to properties for immutability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Filesystem.php

<li>Added <code>readonly</code> keyword to <code>Config</code> and <code>PathNormalizer</code> properties.<br> <li> Enhanced immutability of the <code>Filesystem</code> class.<br>


</details>


  </td>
  <td><a href="https://github.com/VicTest1234/flysystem/pull/1/files#diff-1bf4a3b5dc916cddd3d67187953821a368875d3756693b5c7d242624d1ad2869">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information